### PR TITLE
DM-55688: Move dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'thursday'
-      time: '09:00'
-      timezone: America/Toronto
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Move the `github-actions` dependabot entry from weekly (Thursday 09:00 America/Toronto) to monthly (03:00 America/New_York) cadence.
- Add a wildcard `github-actions` group so all GitHub Actions bumps land in a single grouped PR.

This repo only has a `.github/dependabot.yml` github-actions entry — no Dockerfile, no pip/npm lockfiles, so no additional ecosystem entries were needed.

Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

## Test plan
- [x] `grep -nE "interval: ['\"]?(weekly|daily)" .github/dependabot.yml` prints nothing
- [x] `grep -c "interval: "` equals `grep -c "monthly"` (1 == 1)
- [x] every `updates:` entry has a `groups:` key
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` exits 0

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ